### PR TITLE
Use empty string as default robots_txt

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -25,4 +25,4 @@ gitea::service_template: 'gitea/systemd.erb'
 gitea::service_path: '/lib/systemd/system/gitea.service'
 gitea::service_provider: 'systemd'
 gitea::service_mode: '0644'
-gitea::robots_txt: ~
+gitea::robots_txt: ''


### PR DESCRIPTION
Avoid error on default setup

> Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Class[Gitea]: parameter 'robots_txt' expects a String value, got Undef